### PR TITLE
Rework drum fill effect setup

### DIFF
--- a/Assets/Script/Gameplay/Player/DrumsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/DrumsPlayer.cs
@@ -56,7 +56,9 @@ namespace YARG.Gameplay.Player
         protected override InstrumentDifficulty<DrumNote> GetNotes(SongChart chart)
         {
             var track = chart.GetDrumsTrack(Player.Profile.CurrentInstrument).Clone();
-            return track.GetDifficulty(Player.Profile.CurrentDifficulty);
+            var instrumentDifficulty = track.GetDifficulty(Player.Profile.CurrentDifficulty);
+            instrumentDifficulty.SetDrumActivationFlags(Player.Profile.StarPowerActivationType);
+            return instrumentDifficulty;
         }
 
         protected override DrumsEngine CreateEngine()
@@ -147,67 +149,7 @@ namespace YARG.Gameplay.Player
             _kickFretFlash.Initialize(colors.GetParticleColor(0).ToUnityColor());
 
             // Set up drum fill lead-ups
-            PopulateDrumFills();
-        }
-
-        // TODO: Move this logic back into Core where it belongs
-        private void PopulateDrumFills()
-        {
-            // Use checkpointing to only iterate through the notes once
-            int checkpoint = 0;
-
-            foreach (var effect in _trackEffects)
-            {
-                for (int i = checkpoint; i < Notes.Count; i++)
-                {
-                    checkpoint = i;
-
-                    // If the current note is outside of the target phrase or if we have exhausted all notes
-                    if (Notes[i].Time >= effect.TimeEnd || i == Notes.Count - 1)
-                    {
-                        // Get the rightmost pad
-                        var rightmostNote = Notes[i].ParentOrSelf;
-                        foreach (var note in Notes[i].AllNotes)
-                        {
-                            if (note.Pad > rightmostNote.Pad)
-                            {
-                                rightmostNote = note;
-                            }
-
-                            // Set every note on this tick as an activation note in the case of AllNotes
-                            if (Player.Profile.StarPowerActivationType is StarPowerActivationType.AllNotes)
-                            {
-                                note.DrumFlags |= DrumNoteFlags.StarPowerActivator;
-                            }
-                        }
-
-                        // Only set the rightmost activation note in the case of RightmostNote
-                        if (Player.Profile.StarPowerActivationType is StarPowerActivationType.RightmostNote)
-                        {
-                            rightmostNote.DrumFlags |= DrumNoteFlags.StarPowerActivator;
-                        }
-
-                        int fillLane = rightmostNote.Pad;
-
-                        // Convert pad to lane for pro
-                        if (Player.Profile.CurrentInstrument == Instrument.ProDrums)
-                        {
-                            if (Player.Profile.SplitProTomsAndCymbals)
-                            {
-                                fillLane = GetFillLaneForSplitView(fillLane);
-                            }
-                            else if (fillLane > 4)
-                            {
-                                fillLane -= 3;
-                            }
-                        }
-
-                        effect.FillLane = fillLane;
-                        effect.TotalLanes = _fretArray.FretCount;
-                        break;
-                    }
-                }
-            }
+            SetDrumFillEffects();
         }
 
         private int GetFillLaneForSplitView(int rightmostPad)
@@ -224,6 +166,93 @@ namespace YARG.Gameplay.Player
                 7 => ShouldSwapCrashAndRide() ? 4 : 6,
                 _ => 0,
             };
+        }
+
+        private void SetDrumFillEffects()
+        {
+            int checkpoint = 0;
+            var pairedFillIndexes = new HashSet<int>();
+
+            // Find activation gems
+            foreach (var chord in Notes)
+            {
+                DrumNote rightmostNote = chord.ParentOrSelf;
+                bool foundStarpower = false;
+
+                // Check for SP activation note
+                foreach (var note in chord.AllNotes)
+                {
+                    rightmostNote = note;
+
+                    if (note.IsStarPowerActivator)
+                    {
+                        if (note.Pad > rightmostNote.Pad)
+                        {
+                            rightmostNote = note;
+                        }
+                        foundStarpower = true;
+                    }
+                }
+
+                if (!foundStarpower)
+                {
+                    continue;
+                }
+
+                int fillLane = rightmostNote.Pad;
+
+                // Convert pad to lane for pro
+                if (Player.Profile.CurrentInstrument == Instrument.ProDrums)
+                {
+                    if (Player.Profile.SplitProTomsAndCymbals)
+                    {
+                        fillLane = GetFillLaneForSplitView(fillLane);
+                    }
+                    else if (fillLane > 4)
+                    {
+                        fillLane -= 3;
+                    }
+                }
+
+                int candidateIndex = -1;
+
+                // Find the drum fill immediately before this note
+                for (var i = checkpoint; i < _trackEffects.Count; i++)
+                {
+                    if (_trackEffects[i].EffectType != TrackEffectType.DrumFill)
+                    {
+                        continue;
+                    }
+
+                    var effect = _trackEffects[i];
+
+                    if (effect.TimeEnd <= chord.Time)
+                    {
+                        candidateIndex = i;
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+
+                if (candidateIndex != -1)
+                {
+                    _trackEffects[candidateIndex].FillLane = fillLane;
+                    _trackEffects[candidateIndex].TotalLanes = _fretArray.FretCount;
+                    pairedFillIndexes.Add(candidateIndex);
+                    checkpoint = candidateIndex;
+                }
+            }
+
+            // Remove fills that are not paired with a note
+            for (var i = _trackEffects.Count - 1; i >= 0; i--)
+            {
+                if (_trackEffects[i].EffectType == TrackEffectType.DrumFill && !pairedFillIndexes.Contains(i))
+                {
+                    _trackEffects.RemoveAt(i);
+                }
+            }
         }
 
         public override void SetStemMuteState(bool muted)


### PR DESCRIPTION
Splits into two separate phases, first setting up the activation notes and only later adding the info to the track effects. Also removes any drum fill track effects that go unused because of "no kicks" or other modifiers that invalidate drum fills.